### PR TITLE
Subnet name conflict in same region

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Public subnet access internet through Default Internet gateway and private subne
     }
   }
   ```
+
+- `subnets_names: list(string)`
+  - The names of the subnets being created
+  
+- `subnets_ids: list(string)`
+  - The IDs of the subnets being created
+  
 - `cloud_nat: string` 
   - Id of Cloud NAT (For example: `experimental-320320/us-west1/nullstone-vpc-router/nullstone-vpc-nat`)
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ Public subnet access internet through Default Internet gateway and private subne
   }
   ```
 
-- `subnets_names: list(string)`
-  - The names of the subnets being created
-  
-- `subnets_ids: list(string)`
-  - The IDs of the subnets being created
-  
+- `public_subnet_names: list(string)`
+  - The names of the public  subnets being created
+
+- `private_subnet_names: list(string)`
+  - The names of the private subnets being created
+
+- `public_subnets_ids: list(string)`
+  - The IDs of the public subnets being created
+
+- `private_subnets_ids: list(string)`
+  - The IDs of the private subnets being created
+ 
 - `cloud_nat: string` 
   - Id of Cloud NAT (For example: `experimental-320320/us-west1/nullstone-vpc-router/nullstone-vpc-nat`)
 

--- a/network.tf
+++ b/network.tf
@@ -10,7 +10,7 @@ module "gcp-network" {
     # Public subnet
     flatten([
       for index, subnet_cidr in var.public_subnets : {
-        subnet_name   = "public-subnet-${index + 1}"
+        subnet_name   = "${local.resource_name}-public-${index + 1}"
         subnet_ip     = subnet_cidr
         subnet_region = data.google_compute_zones.available.region
       }
@@ -19,7 +19,7 @@ module "gcp-network" {
     # Private subnet
     flatten([
       for index, subnet_cidr in var.private_subnets : {
-        subnet_name           = "private-subnet-${index + 1}"
+        subnet_name           = "${local.resource_name}-private-${index + 1}"
         subnet_ip             = subnet_cidr
         subnet_region         = data.google_compute_zones.available.region
         subnet_private_access = "true"
@@ -41,7 +41,7 @@ resource "google_compute_router_nat" "nat" {
   dynamic "subnetwork" {
     for_each = var.private_subnets
     content {
-      name                    = "private-subnet-${subnetwork.key + 1}"
+      name                    = "${local.resource_name}-private-${subnetwork.key + 1}"
       source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,14 +8,32 @@ output "subnets" {
   description = "map ||| A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets."
 }
 
-output "subnets_names" {
-  value       = module.gcp-network.subnets_names
-  description = "list(string) ||| The names of the subnets being created"
+output "public_subnet_names" {
+  value = [
+    for subnet_name in module.gcp-network.subnets_names : subnet_name if length(regexall("((.+)-public-[0-9]+)", subnet_name)) > 0
+  ]
+  description = "list(string) ||| The names of the public subnets being created"
 }
 
-output "subnets_ids" {
-  value       = module.gcp-network.subnets_ids
-  description = "list(string) ||| The IDs of the subnets being created"
+output "private_subnet_names" {
+  value = [
+    for subnet_name in module.gcp-network.subnets_names : subnet_name if length(regexall("((.+)-private-[0-9]+)", subnet_name)) > 0
+  ]
+  description = "list(string) ||| The names of the private subnets being created"
+}
+
+output "public_subnets_ids" {
+  value = [
+    for subnet_id in module.gcp-network.subnets_ids : subnet_id if length(regexall("((.+)-public-[0-9]+)", subnet_id)) > 0
+  ]
+  description = "list(string) ||| The IDs of the public subnets being created"
+}
+
+output "private_subnets_ids" {
+  value = [
+    for subnet_id in module.gcp-network.subnets_ids : subnet_id if length(regexall("((.+)-private-[0-9]+)", subnet_id)) > 0
+  ]
+  description = "list(string) ||| The IDs of the private subnets being created"
 }
 
 output "cloud_nat" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,16 @@ output "subnets" {
   description = "map ||| A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets."
 }
 
+output "subnets_names" {
+  value       = module.gcp-network.subnets_names
+  description = "list(string) ||| The names of the subnets being created"
+}
+
+output "subnets_ids" {
+  value       = module.gcp-network.subnets_ids
+  description = "list(string) ||| The IDs of the subnets being created"
+}
+
 output "cloud_nat" {
   value       = google_compute_router_nat.nat.id
   description = "string ||| Id of Cloud NAT"


### PR DESCRIPTION
* Fix for "Within a project, subnets in the same region must have unique names." Reference [Subnet rules](https://cloud.google.com/vpc/docs/using-vpc#subnet-rules)
